### PR TITLE
#26 - Added throwing ctor to Data for ambiguous hex string values

### DIFF
--- a/Example/Tests/Data/DataTests.swift
+++ b/Example/Tests/Data/DataTests.swift
@@ -1,0 +1,48 @@
+//
+// Created by Timofey on 3/1/18.
+// Copyright (c) 2018 CocoaPods. All rights reserved.
+//
+
+import Nimble
+import Quick
+@testable import Web3Swift
+
+final class DataTests: XCTestCase {
+
+    func testAmbiguousHexThrowsFor1() {
+        expect{
+            try Data(hexValue: "0x1")
+        }.to(
+            throwError(),
+            description: "Ambiguous hex value is expected to result into an exception"
+        )
+    }
+
+    func testAmbiguousHexThrowsFor1023() {
+        expect{
+            try Data(hexValue: "0x3ff")
+        }.to(
+            throwError(),
+            description: "Ambiguous hex value is expected to result into an exception"
+        )
+    }
+
+    func testCorrectHex1() {
+        expect{
+            try Data(hexValue: "0x01")
+        }.to(
+            equal(Data(bytes: [0x01])),
+            description: "Data created with this hex string is expected to match the bytes it represents"
+        )
+    }
+
+    func testCorrectHex1023() {
+        expect{
+            try Data(hexValue: "0x03ff")
+        }.to(
+            equal(Data(bytes: [0x03, 0xff])),
+            description: "Data created with this hex string is expected to match the bytes it represents"
+        )
+    }
+
+}

--- a/Example/Web3Swift.xcodeproj/project.pbxproj
+++ b/Example/Web3Swift.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		584FA848F23C434B6D50B7C3 /* RLPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FACC5A38F59EE5FCD2BC7 /* RLPTests.swift */; };
 		584FA9DBA01B7EAE9EC1021B /* EthTransactionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FAE325995A0ABA7A8A643 /* EthTransactionsTests.swift */; };
 		584FAA14203BE4FA51BD4A13 /* GetGasPriceProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FACF870DFF799329F558F /* GetGasPriceProcedureTests.swift */; };
+		584FAC872236D4D12AA6C0F6 /* DataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FA2C7D2205CF3D85F6DD7 /* DataTests.swift */; };
 		584FACDDE9E98EDA9C414EF6 /* RandomNonceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FAB47440D3CE3C6ED0684 /* RandomNonceTests.swift */; };
 		584FACEC7F5AD9060590ED93 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FA82731B90F65C00992E6 /* URL.swift */; };
 		584FAD3793AFB655815DBBA6 /* ChainIDProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584FA8BDDA8B4B1DF68FA7AA /* ChainIDProcedureTests.swift */; };
@@ -57,6 +58,7 @@
 		2F320EB26501545845D58F10 /* Web3Swift.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Web3Swift.podspec; path = ../Web3Swift.podspec; sourceTree = "<group>"; };
 		343D350F5D884606EEA5C913 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		584FA147B4074725F6630283 /* SECP256k1SignatureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SECP256k1SignatureTests.swift; sourceTree = "<group>"; };
+		584FA2C7D2205CF3D85F6DD7 /* DataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataTests.swift; sourceTree = "<group>"; };
 		584FA371F4A75FBAC4AE2D7D /* Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		584FA6C98ECA780456027E15 /* ByteWidthTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByteWidthTests.swift; sourceTree = "<group>"; };
 		584FA82731B90F65C00992E6 /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
@@ -136,6 +138,14 @@
 				8C748B9620408A4800F40AF9 /* InfuraNetworkTests.swift */,
 			);
 			path = Network;
+			sourceTree = "<group>";
+		};
+		584FA5170936BD947884AE75 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				584FA2C7D2205CF3D85F6DD7 /* DataTests.swift */,
+			);
+			path = Data;
 			sourceTree = "<group>";
 		};
 		584FA570513D0B01E7E12749 /* Transactions */ = {
@@ -257,6 +267,7 @@
 				584FA71CD28EA64EC86A73DE /* Entropy */,
 				584FA7FDA8ECE17E99DE5A4D /* Other */,
 				584FA7594A5B6ACEE1F669C4 /* ECRecoverableSignature */,
+				584FA5170936BD947884AE75 /* Data */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -620,6 +631,7 @@
 				584FA538B1B4B38D0AD9D0C9 /* SECP256k1SignatureTests.swift in Sources */,
 				584FADD6EB5CAA11200C1147 /* Collection.swift in Sources */,
 				584FACEC7F5AD9060590ED93 /* URL.swift in Sources */,
+				584FAC872236D4D12AA6C0F6 /* DataTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Web3Swift/Address/SimpleAddress.swift
+++ b/Web3Swift/Address/SimpleAddress.swift
@@ -23,7 +23,7 @@ public final class IncorrectAddressLengthError: DescribedError {
 /// Ethereum address object basic implementation
 public final class SimpleAddress: Address {
     
-    private let value: String
+    private let hex: Hex
     
     /**
     ctor
@@ -36,22 +36,21 @@ public final class SimpleAddress: Address {
      */
     init(hex: Hex) throws {
         guard hex.toString().count == 40 else { throw IncorrectAddressLengthError(length: hex.toString().count) }
-        self.value = hex.toPrefixString()
+        self.hex = hex
     }
 
     /**
     Converts Ethereum address to string
      
     - returns:
-    A prefixed hex string of length 40
+    An prefixed hex string of length 42
      */
     public func toString() -> String {
-        return value
+        return hex.toPrefixString()
     }
-    
-    private lazy var asData: Data = Data(hex: self.value.removingHexPrefix())
+
     public func toData() -> Data {
-        return asData
+        return hex.toBytes()
     }
 
 }

--- a/Web3Swift/Extensions/Data.swift
+++ b/Web3Swift/Extensions/Data.swift
@@ -2,9 +2,34 @@
 // Created by Timofey on 1/28/18.
 //
 
+import CryptoSwift
 import Foundation
 
+private final class AmbiguousHexStringError: DescribedError {
+
+    private let hexValue: String
+    init(hexValue: String) {
+        self.hexValue = hexValue
+    }
+
+    var description: String {
+        return "Hex string \(hexValue) length \(hexValue.count) is not even"
+    }
+
+}
+
 extension Data {
+
+    /**
+    ctor
+
+    - throws:
+    If `hexValue` is ambiguous a `DescribedError` is thrown
+    */
+    init(hexValue: String) throws {
+        guard hexValue.count.isEven() else { throw AmbiguousHexStringError(hexValue: hexValue) }
+        self = Data(hex: hexValue)
+    }
 
     init(integer: UInt) {
         var integerCopy = integer

--- a/Web3Swift/Extensions/Int.swift
+++ b/Web3Swift/Extensions/Int.swift
@@ -23,4 +23,14 @@ extension Int {
         return (self.bitWidth - self.leadingZeroBitCount - 1).unsafeDivided(by: 8) + 1
     }
 
+    /**
+    Tells if Int is even (divisible by 2 with 0 as a remainder)
+
+    - returns:
+    true if even, false if odd
+    */
+    func isEven() -> Bool {
+        return self % 2 == 0
+    }
+
 }

--- a/Web3Swift/Hex/Hex.swift
+++ b/Web3Swift/Hex/Hex.swift
@@ -16,5 +16,13 @@ public protocol Hex {
     func toString() -> String
     
     func toPrefixString() -> String
+
+    /**
+    Bytes of the Hex
+
+    - returns:
+    Data which represents bytes of the Hex
+    */
+    func toBytes() -> Data
     
 }

--- a/Web3Swift/Hex/SimpleHex.swift
+++ b/Web3Swift/Hex/SimpleHex.swift
@@ -30,7 +30,13 @@ public final class IncorrectHexCharacterError: DescribedError {
 public final class SimpleHex: Hex {
     
     private let hex: String
-    
+    private let bytes: Data
+    /**
+    ctor
+
+    - throws:
+    Throws `DescribedError` if something goes wrong
+    */
     init(value: String) throws {
         
         var hexString = value
@@ -47,7 +53,7 @@ public final class SimpleHex: Hex {
         }
         
         hex = hexString
-    
+        bytes = try Data(hexValue: hexString)
     }
     
     /**
@@ -68,6 +74,10 @@ public final class SimpleHex: Hex {
     */
     public func toPrefixString() -> String {
         return hex.addingHexPrefix()
+    }
+
+    public func toBytes() -> Data {
+        return bytes
     }
     
 }


### PR DESCRIPTION
1. To resolve #26 I added a ctor for `Data` throwing in case hex string provided is not even. I added relevant test for the ctor. 
2. I expanded `Hex` interface to give of bytes the `Hex` represents because `SimpleAddress` that was supposed to give its bytes (`toData()` method) was using the ambiguous `Data` ctor.